### PR TITLE
Update name of the workshop and links

### DIFF
--- a/Challenge/README.md
+++ b/Challenge/README.md
@@ -1,6 +1,6 @@
 # Data Challenge 
 
-### GW Open Data Workshop #6
+### GW Open Data Workshop #7
 
 Challenge activity for the Open Data Workshop 2023: https://gwosc.org/odw/odw2023/
 

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "## Software installation  (execute only if running on a cloud platform or haven't done the installation yet!)\n",
     "\n",
-    "First, we need to install the software, which we do following the instruction in [Software Setup Instructions](https://github.com/gw-odw/odw-2021/blob/master/setup.md):"
+    "First, we need to install the software, which we do following the instruction in [Software Setup Instructions](https://github.com/gw-odw/odw-2024/blob/master/setup.md):"
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "#### Tutorial 1.1: Discovering open data from GW observatories\n",

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -8,7 +8,7 @@
     "id": "R_adEak0Q8NT"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -8,7 +8,7 @@
     "id": "R_adEak0Q8NT"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
@@ -66,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The version you get should be 0.7.1. If it's not, check that you have followed all the steps in [Software Setup Instructions](https://github.com/gw-odw/odw-2023/blob/main/setup.md)."
+    "The version you get should be 0.7.1. If it's not, check that you have followed all the steps in [Software Setup Instructions](https://github.com/gw-odw/odw-2024/blob/main/setup.md)."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "## Software installation  (execute only if running on a cloud platform or haven't done the installation yet!)\n",
     "\n",
-    "First, we need to install the software, which we do following the instruction in [Software Setup Instructions](https://github.com/gw-odw/odw-2024/blob/master/setup.md):"
+    "First, we need to install the software, which we do following the instruction in [Software Setup Instructions](../../setup.md):"
    ]
   },
   {
@@ -66,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The version you get should be 0.7.1. If it's not, check that you have followed all the steps in [Software Setup Instructions](https://github.com/gw-odw/odw-2024/blob/main/setup.md)."
+    "The version you get should be 0.7.1. If it's not, check that you have followed all the steps in [Software Setup Instructions](../../setup.md)."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "##  Installation  (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)\n",
     "\n",
-    "Note: we use [`pip`](https://docs.python.org/3.9/installing/), but **it is recommended** to use [conda](https://computing.docs.ligo.org/conda/) on your own machine, as explained in the [installation instructions](https://github.com/gw-odw/odw-2024/blob/main/setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
+    "Note: we use [`pip`](https://docs.python.org/3.9/installing/), but **it is recommended** to use [conda](https://computing.docs.ligo.org/conda/) on your own machine, as explained in the [installation instructions](../../setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -8,7 +8,7 @@
     "id": "tcXQnfN0vvWt"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "#### Tutorial 1.2: Introduction to GWpy\n",

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -8,7 +8,7 @@
     "id": "tcXQnfN0vvWt"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
@@ -33,7 +33,7 @@
    "source": [
     "##  Installation  (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)\n",
     "\n",
-    "Note: we use [`pip`](https://docs.python.org/3.9/installing/), but **it is recommended** to use [conda](https://computing.docs.ligo.org/conda/) on your own machine, as explained in the [installation instructions](https://github.com/gw-odw/odw-2023/blob/main/setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
+    "Note: we use [`pip`](https://docs.python.org/3.9/installing/), but **it is recommended** to use [conda](https://computing.docs.ligo.org/conda/) on your own machine, as explained in the [installation instructions](https://github.com/gw-odw/odw-2024/blob/main/setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "##  Installation  (execute only if running on a cloud platform or if you haven't done the installation already!)\n",
     "\n",
-    "PyCBC is installable through pip. It relies on portions of the [LALSuite](https://lscsoft.docs.ligo.org/lalsuite/) C-library. A bundled version of this suitable for use with PyCBC is also available on Mac / Linux through pip. **It is recommended** to use [conda](https://docs.ligo.org/lscsoft/conda/) on your own machine, as explained in the [installation instructions](https://github.com/gw-odw/odw-2024/blob/master/setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
+    "PyCBC is installable through pip. It relies on portions of the [LALSuite](https://lscsoft.docs.ligo.org/lalsuite/) C-library. A bundled version of this suitable for use with PyCBC is also available on Mac / Linux through pip. **It is recommended** to use [conda](https://docs.ligo.org/lscsoft/conda/) on your own machine, as explained in the [installation instructions](../../setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "##  Installation  (execute only if running on a cloud platform or if you haven't done the installation already!)\n",
     "\n",
-    "PyCBC is installable through pip. It relies on portions of the [LALSuite](https://lscsoft.docs.ligo.org/lalsuite/) C-library. A bundled version of this suitable for use with PyCBC is also available on Mac / Linux through pip. **It is recommended** to use [conda](https://docs.ligo.org/lscsoft/conda/) on your own machine, as explained in the [installation instructions](https://github.com/gw-odw/odw-2019/blob/master/setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
+    "PyCBC is installable through pip. It relies on portions of the [LALSuite](https://lscsoft.docs.ligo.org/lalsuite/) C-library. A bundled version of this suitable for use with PyCBC is also available on Mac / Linux through pip. **It is recommended** to use [conda](https://docs.ligo.org/lscsoft/conda/) on your own machine, as explained in the [installation instructions](https://github.com/gw-odw/odw-2024/blob/master/setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -8,7 +8,7 @@
     "id": "_aI2xJ4qzarB"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop\n",
     "\n",

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -8,7 +8,7 @@
     "id": "_aI2xJ4qzarB"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop\n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -8,7 +8,7 @@
     "id": "D_QUDECR0psB"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "## Tutorial 2.1 PyCBC Tutorial, An introduction to matched-filtering\n",

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -8,7 +8,7 @@
     "id": "D_QUDECR0psB"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -8,7 +8,7 @@
     "id": "d9O1zsAO1zul"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "## Tutorial 2.2 PyCBC Tutorial, Matched Filtering in Action\n",

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -8,7 +8,7 @@
     "id": "d9O1zsAO1zul"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
@@ -650,9 +650,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Getting : https://github.com/gw-odw/odw-2023/raw/main/Tutorials/Day_2/Data/PyCBC_T2_0.gwf\n",
-      "Getting : https://github.com/gw-odw/odw-2023/raw/main/Tutorials/Day_2/Data/PyCBC_T2_1.gwf\n",
-      "Getting : https://github.com/gw-odw/odw-2023/raw/main/Tutorials/Day_2/Data/PyCBC_T2_2.gwf\n"
+      "Getting : https://github.com/gw-odw/odw-2024/raw/main/Tutorials/Day_2/Data/PyCBC_T2_0.gwf\n",
+      "Getting : https://github.com/gw-odw/odw-2024/raw/main/Tutorials/Day_2/Data/PyCBC_T2_1.gwf\n",
+      "Getting : https://github.com/gw-odw/odw-2024/raw/main/Tutorials/Day_2/Data/PyCBC_T2_2.gwf\n"
      ]
     }
    ],
@@ -662,7 +662,7 @@
     "import urllib\n",
     "\n",
     "def get_file(fname):\n",
-    "    url = \"https://github.com/gw-odw/odw-2023/raw/main/Tutorials/Day_2/Data/{}\"\n",
+    "    url = \"https://github.com/gw-odw/odw-2024/raw/main/Tutorials/Day_2/Data/{}\"\n",
     "    url = url.format(fname)\n",
     "    urllib.request.urlretrieve(url, fname)\n",
     "    print('Getting : {}'.format(url))\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -8,7 +8,7 @@
     "id": "omeA9c5XCLJJ"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
@@ -709,7 +709,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Getting : https://github.com/gw-odw/odw-2023/raw/main/Tutorials/Day_2/Data/PyCBC_T3_0.gwf\n"
+      "Getting : https://github.com/gw-odw/odw-2024/raw/main/Tutorials/Day_2/Data/PyCBC_T3_0.gwf\n"
      ]
     }
    ],
@@ -719,7 +719,7 @@
     "import urllib.request\n",
     "\n",
     "def get_file(fname):\n",
-    "    url = \"https://github.com/gw-odw/odw-2023/raw/main/Tutorials/Day_2/Data/{}\"\n",
+    "    url = \"https://github.com/gw-odw/odw-2024/raw/main/Tutorials/Day_2/Data/{}\"\n",
     "    url = url.format(fname)\n",
     "    urllib.request.urlretrieve(url, fname)\n",
     "    print('Getting : {}'.format(url))\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "## Tutorial 2.3: PyCBC Tutorial, Signal Consistency and Significance\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -8,7 +8,7 @@
     "id": "omeA9c5XCLJJ"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -7,7 +7,7 @@
     "id": "a2a21b4e"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
@@ -78,7 +78,7 @@
     "import os\n",
     "if not os.path.isfile(\"toy_model.csv\"):\n",
     "  print(\"Downloading toy_model.csv\")\n",
-    "  ! wget https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/Day_3/toy_model.csv\n",
+    "  ! wget https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/Day_3/toy_model.csv\n",
     "else:\n",
     "  print(\"toy_model.csv exists; not downloading\")"
    ]

--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -7,7 +7,7 @@
     "id": "a2a21b4e"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",

--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -10,7 +10,7 @@
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "## Tutorial 3.1: An introduction to parameter estimation\n",

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -8,7 +8,7 @@
     "id": "OjUNeFsxyguu"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -11,7 +11,7 @@
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "## Tutorial 3.2: Parameter estimation for compact object mergers\n",

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -8,7 +8,7 @@
     "id": "OjUNeFsxyguu"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -7,7 +7,7 @@
     "id": "quA5zQqJ3DkE"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -7,7 +7,7 @@
     "id": "quA5zQqJ3DkE"
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "\n",
     "#### Tutorial 3.3: Discovering and using published posterior samples\n",

--- a/Tutorials/Extension_topics/README.md
+++ b/Tutorials/Extension_topics/README.md
@@ -4,4 +4,4 @@ Tutorial A.1 requires a `conda` environment to run.
 
 The `IGWN` conda environment is advised: [documentation](https://computing.docs.ligo.org/conda/).
 
-Instructions on setting up your own environment are available [on this page](https://github.com/gw-odw/odw-2024/blob/main/setup.md) (option 3).
+Instructions on setting up your own environment are available [on this page](../../setup.md) (option 3).

--- a/Tutorials/Extension_topics/README.md
+++ b/Tutorials/Extension_topics/README.md
@@ -4,4 +4,4 @@ Tutorial A.1 requires a `conda` environment to run.
 
 The `IGWN` conda environment is advised: [documentation](https://computing.docs.ligo.org/conda/).
 
-Instructions on setting up your own environment are available [on this page](https://github.com/gw-odw/odw-2023/blob/main/setup.md) (option 3).
+Instructions on setting up your own environment are available [on this page](https://github.com/gw-odw/odw-2024/blob/main/setup.md) (option 3).

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #6\n",
+    "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
     "#### Tutorial A.1: Parameter estimation on GW190828_063405 using GWOSC data and LALInference software.\n",
     "\n",

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -7,7 +7,7 @@
     "tags": []
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+    "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -7,7 +7,7 @@
     "tags": []
    },
    "source": [
-    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+    "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
     "\n",
     "#  Gravitational Wave Open Data Workshop #7\n",
     "\n",
@@ -28,7 +28,7 @@
     "\n",
     "It is advised to use the official `IGWN` environment, see the [documentation](https://computing.docs.ligo.org/conda/) for details and instructions.\n",
     "\n",
-    "Instructions about setting up a `conda` environment are available on [this page](https://github.com/gw-odw/odw-2023/blob/main/setup.md) (option 3). \n",
+    "Instructions about setting up a `conda` environment are available on [this page](https://github.com/gw-odw/odw-2024/blob/main/setup.md) (option 3). \n",
     "The following packages must be installed in the conda environment: \n",
     "- `conda install --channel conda-forge lalsuite` \n",
     "- `conda install -c conda-forge pesummary`\n",

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "It is advised to use the official `IGWN` environment, see the [documentation](https://computing.docs.ligo.org/conda/) for details and instructions.\n",
     "\n",
-    "Instructions about setting up a `conda` environment are available on [this page](https://github.com/gw-odw/odw-2024/blob/main/setup.md) (option 3). \n",
+    "Instructions about setting up a `conda` environment are available on [this page](../../setup.md) (option 3). \n",
     "The following packages must be installed in the conda environment: \n",
     "- `conda install --channel conda-forge lalsuite` \n",
     "- `conda install -c conda-forge pesummary`\n",

--- a/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
@@ -7,7 +7,7 @@
         "id": "quA5zQqJ3DkE"
       },
       "source": [
-        "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
+        "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
         "\n",
         "#  Gravitational Wave Open Data Workshop #7\n",
         "\n",

--- a/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
@@ -7,7 +7,7 @@
         "id": "quA5zQqJ3DkE"
       },
       "source": [
-        "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2024/main/Tutorials/logo.png\">  \n",
+        "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
         "\n",
         "#  Gravitational Wave Open Data Workshop #7\n",
         "\n",

--- a/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
@@ -9,7 +9,7 @@
       "source": [
         "<img style=\"float: left;padding: 1.3em\" src=\"https://raw.githubusercontent.com/gw-odw/odw-2023/main/Tutorials/logo.png\">  \n",
         "\n",
-        "#  Gravitational Wave Open Data Workshop #6\n",
+        "#  Gravitational Wave Open Data Workshop #7\n",
         "\n",
         "\n",
         "#### Tutorial 3.3:  Population Inference with Gravitational Wave Data\n",

--- a/Tutorials/Solutions/README.md
+++ b/Tutorials/Solutions/README.md
@@ -1,6 +1,6 @@
 # ODW solution repo
 
-This repository contains the encrypted solutions to the quizzes and challenges proposed at the [ODW6, 2023](https://github.com/gw-odw/odw-2023). To see the solutions, you need to be in possession of the secret key. Once you have this, you can run
+This repository contains the encrypted solutions to the quizzes and challenges proposed at the [ODW7, 2024](https://github.com/gw-odw/odw-2024). To see the solutions, you need to be in possession of the secret key. Once you have this, you can run
 ```
 $ gpg -d solutions.tar.gz.gpg | tar -xvzf -
 ```

--- a/setup.md
+++ b/setup.md
@@ -41,7 +41,7 @@ The various options are listed in order of difficulty. However, whenever possibl
 
 To run the notebooks, click the badge:  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gw-odw/odw-2024/HEAD)
 
-This will build a Docker image (if not already present) with the dependency file `environment.yml`. Then a [JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) server will be open hosting the contents of the `gw-odw/odw-2023` repo. To find the Tutorials, click the folders `Tutorials`, and then `Day 1`, `Day 2`, or `Day 3` to find the tutorials.
+This will build a Docker image (if not already present) with the dependency file `environment.yml`. Then a [JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) server will be open hosting the contents of the `gw-odw/odw-2024` repo. To find the Tutorials, click the folders `Tutorials`, and then `Day 1`, `Day 2`, or `Day 3` to find the tutorials.
 
 
 ## Option 3: You have a Linux or Apple/Mac computer -- Use conda
@@ -94,7 +94,7 @@ This guide will walk you through the configuration of these environments with [C
 
 6. Clone the workshop git repo 
 
-    `git clone https://github.com/gw-odw/odw-2023.git`
+    `git clone https://github.com/gw-odw/odw-2024.git`
 
 7. Move into the directory with the workshop git repo 
 


### PR DESCRIPTION
This PR updates the name of the workshop (from `GW Open Data Workshop #6` to `GW Open Data Workshop #7`) and the links to the repo (images, links to instructions) in the notebooks (some were old see e7c0f8f).

In the process, I realized that you can use relative links to a file in the repo (see f68d8ff) which should reduce the number of links to update in the future. This specially useful for the logo (see 0b82765).

Most of the changes are done with `sed`.