### PR TITLE
Clarify the way we locate executables in Extention Topic A.1

### DIFF
--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -593,14 +593,21 @@
     "tags": []
    },
    "source": [
-    "The location of the executable(s) depends on the machine and the method you used to install the software.\n",
-    "In order to find them, we will use the `which` function (from the `shutil` package).\n",
     "Then we chose the executable and relevant options from the `analysis` and `engine` sections of the config options.\n",
     "\n",
+    "The location of the executable(s) depends on the machine and the method you used to install the software.\n",
+    "In order to find them, we will use the `which` function (from the `shutil` package)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2911ebb-96da-4b64-8869-d483e1f1d38b",
+   "metadata": {},
+   "source": [
     "**For nested sampling**, we need to specify: \n",
     "- the number of live points `nlive` \n",
     "- the number of points `maxmcmc` for independent MCMC chains (optional)\n",
-    "- the tolerance on the evidence `tolerance` to obtain to stop the inference (optional)\n"
+    "- the tolerance on the evidence `tolerance` to obtain to stop the inference (optional)"
    ]
   },
   {

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -125,7 +125,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os \n",
+    "import os\n",
+    "import shutil\n",
     "import lal\n",
     "import json\n",
     "import numpy as np\n",
@@ -587,46 +588,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11e1dc09-7a5c-4ff4-8d7a-911da6e36488",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### - Specify the inference executable\n",
-    "\n",
-    "First specify the `conda` environment where LAL is installed. The path needs to be modified according to your machine, specifying the link to the virtual environment. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "e3b93121-cb6d-4b34-80cb-f7362fa4b9b6",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/home/jerry/miniforge3/envs/odw-2024-test/bin/lalinference_nest\n"
-     ]
-    }
-   ],
-   "source": [
-    "env_path = '/cvmfs/oasis.opensciencegrid.org/ligo/sw/conda/envs/igwn-py38/'\n",
-    "\n",
-    "# Here we use the following command to find out the path to the binary file of the command \"lalinference_nest\":\n",
-    "! which lalinference_nest\n",
-    "# Then we specify the correct path:\n",
-    "env_path = '/home/jerry/miniforge3/envs/odw-2024-test/'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "dfced366-c9b5-421e-8ed0-ec36e8f488bb",
    "metadata": {
     "tags": []
    },
    "source": [
+    "The location of the executable(s) depends on the machine and the method you used to install the software.\n",
+    "In order to find them, we will use the `which` function (from the `shutil` package).\n",
     "Then we chose the executable and relevant options from the `analysis` and `engine` sections of the config options.\n",
     "\n",
     "**For nested sampling**, we need to specify: \n",
@@ -644,7 +612,7 @@
    "source": [
     "if pe_data.config[label]['analysis']['engine'] == 'lalinferencenest': \n",
     "    with open(run_path, \"w\") as run_file:\n",
-    "        print(env_path + 'bin/lalinference_nest \\\\', file=run_file)\n",
+    "        print(shutil.which(\"lalinference_nest\") + ' \\\\', file=run_file)\n",
     "        print('--nlive ' + pe_data.config[label]['engine']['nlive'] + ' \\\\', file=run_file)\n",
     "        if 'maxmcmc' in pe_data.config[label]['engine']: \n",
     "            print('--maxmcmc ' + pe_data.config[label]['engine']['maxmcmc'] + ' \\\\', file=run_file)\n",
@@ -677,9 +645,9 @@
    "source": [
     "if pe_data.config[label]['analysis']['engine'] == 'lalinferencemcmc': \n",
     "    with open(run_path, \"w\") as run_file:\n",
-    "        print(env_path + 'bin/lalinference_mpi_wrapper \\\\', file=run_file)\n",
-    "        print('--mpirun ' + env_path + 'bin/mpirun \\\\', file=run_file)\n",
-    "        print('--executable ' + env_path + 'bin/lalinference_mcmc \\\\', file=run_file)\n",
+    "        print(shutil.which(\"lalinference_mpi_wrapper\") + ' \\\\', file=run_file)\n",
+    "        print('--mpirun ' + shutil.which(\"mpirun\") + ' \\\\', file=run_file)\n",
+    "        print('--executable ' + shutil.which(\"lalinference_mcmc\") + ' \\\\', file=run_file)\n",
     "        print('--np ' + pe_data.config[label]['engine']['np'] + ' \\\\', file=run_file)\n",
     "\n",
     "        if 'neff' in pe_data.config[label]['engine']: \n",


### PR DESCRIPTION
This PR addresses a part of #10, namely that the way to find the location of executables is not super clear and requires manual modification.

Instead of trying to find the root of the environment where the executables are installed and then construct their location, we simply use `shutil.which` to find them when needed. This is a bit clearer and doesn't require manual intervention. The generated bash file is identical.